### PR TITLE
fixed config file example exporter port field

### DIFF
--- a/maxctrl_exporter.yaml.example
+++ b/maxctrl_exporter.yaml.example
@@ -1,5 +1,5 @@
 url: "http://127.0.0.1:8989"
 username: "maxctrl_username"
 password: "maxctrl_password"
-exporterPort: "8080"
+exporter_port: "8080"
 caCertificate: ""


### PR DESCRIPTION
The example config field is inconsistent with [the code](https://github.com/vbezgachev/maxctrl_exporter/blob/026a04d910f1bd0bc408dd04848928446e1719ce/maxctrl_exporter.go#L51)