### PR TITLE
Adding monitor metrics

### DIFF
--- a/maxscale_api.go
+++ b/maxscale_api.go
@@ -75,6 +75,38 @@ type Services struct {
 	} `json:"data"`
 }
 
+// Monitors structure reflects JSON object returned by MaxScale REST API
+// <maxscale url>/v1/monitors
+type Monitors struct {
+	Links interface {
+	} `json:"links"`
+	Data []struct {
+		ID string `json:"id"`
+		// add other parameters if needed
+		Attributes struct {
+			Module string `json:"module"`
+			//nolint
+			MonitorDiagnostics struct {
+				Primary bool   `json:"primary"`
+				Master  string `json:"master"`
+			} `json:"monitor_diagnostics"`
+			//nolint
+			Parameters struct {
+				CooperativeMonitoringLocks string `json:"cooperative_monitoring_locks"`
+				AutoFailover               bool   `json:"auto_failover"`
+				AutoRejoin                 bool   `json:"auto_rejoin"`
+			} `json:"parameters"`
+			//nolint
+		} `json:"attributes"`
+		//nolint
+		Relationships interface {
+		} `json:"relationships"`
+		//nolint
+		Links interface {
+		} `json:"links"`
+	} `json:"data"`
+}
+
 // MaxscaleStatus structure reflects JSON object returned by MaxScale REST API
 // <maxscale url>/v1/maxscale
 type MaxscaleStatus struct {

--- a/prometheus_metrics.go
+++ b/prometheus_metrics.go
@@ -30,6 +30,7 @@ var (
 	serverLabelNames         = []string{"server", "address"}
 	serverUpLabelNames       = []string{"server", "address", "status"}
 	serviceLabelNames        = []string{"name", "router"}
+	monitorLabelNames        = []string{"name", "cooperative_monitoring_locks"}
 	maxscaleStatusLabelNames = []string{}
 	statusLabelNames         = []string{"id"}
 )
@@ -83,5 +84,11 @@ var (
 		"status_query_classifier_cache_hits":      newDesc("status", "query_classifier_cache_hits", "The number of hits in the query classifier cache", statusLabelNames, prometheus.GaugeValue),
 		"status_query_classifier_cache_misses":    newDesc("status", "query_classifier_cache_misses", "The number of misses in the query classifier cache", statusLabelNames, prometheus.GaugeValue),
 		"status_query_classifier_cache_evictions": newDesc("status", "query_classifier_cache_evictions", "The number of evictions in the query classifier cache", statusLabelNames, prometheus.GaugeValue),
+	}
+
+	MonitorMetrics = metrics{
+		"monitor_primary":       newDesc("monitor", "primary", "Is a primary node", monitorLabelNames, prometheus.GaugeValue),
+		"monitor_auto_failover": newDesc("monitor", "auto_failover", "Is auto-failover enable", monitorLabelNames, prometheus.CounterValue),
+		"monitor_auto_rejoin":   newDesc("monitor", "auto_rejoin", "Is auto-rejoin enable", monitorLabelNames, prometheus.GaugeValue),
 	}
 )


### PR DESCRIPTION
Adding monitor metrics:
* monitor_primary - To monitor who is the primary node (useful when using cooperative monitoring lock)
* monitor_auto_failover - To monitor if the auto_failover is enabled
* monitor_auto_rejoin - To monitor if the auto_rejoin is enabled