### PR TITLE
Added support for Maxscale release 25.x in addition to previous releases

### DIFF
--- a/auto_failover_value.go
+++ b/auto_failover_value.go
@@ -1,0 +1,93 @@
+// © 2026 Nokia
+// Licensed under the Apache License, Version 2.0 (the "License");
+// SPDX-License-Identifier: Apache-2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// AutoFailoverValue is a custom type that can handle both bool (true/false) and string values
+// String values are expected to be one of: "true", "false", or "safe"
+type AutoFailoverValue struct {
+	StringValue string
+	BoolValue   bool
+	IsString    bool
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (a *AutoFailoverValue) UnmarshalJSON(data []byte) error {
+	// Try to unmarshal as bool first
+	var boolValue bool
+	if err := json.Unmarshal(data, &boolValue); err == nil {
+		a.BoolValue = boolValue
+		a.StringValue = ""
+		a.IsString = false
+		return nil
+	}
+
+	// If not a bool, try as string
+	var stringValue string
+	if err := json.Unmarshal(data, &stringValue); err == nil {
+		// Validate that the string is one of the expected enum values
+		lowerValue := strings.ToLower(stringValue)
+		if lowerValue == "true" || lowerValue == "false" || lowerValue == "safe" {
+			a.StringValue = stringValue
+			a.BoolValue = false
+			a.IsString = true
+			return nil
+		} else {
+			// If not a valid enum value, default to "false"
+			a.StringValue = "false"
+			a.BoolValue = false
+			a.IsString = true
+			return nil
+		}
+	}
+
+	// If neither, return error
+	return json.Unmarshal(data, nil)
+}
+
+// MarshalJSON implements the json.Marshaler interface
+func (a AutoFailoverValue) MarshalJSON() ([]byte, error) {
+	if a.IsString {
+		return json.Marshal(a.StringValue)
+	}
+	return json.Marshal(a.BoolValue)
+}
+
+// String returns the string representation
+// For boolean values: true becomes "true", false becomes "false"
+// For string values: returns the original string value ("true", "false", or "safe")
+func (a AutoFailoverValue) String() string {
+	if a.IsString {
+		return a.StringValue
+	}
+	if a.BoolValue {
+		return "true"
+	}
+	return "false"
+}
+
+// Bool returns the boolean value
+// For string values: "true" returns true, "safe" returns true, all others return false
+func (a AutoFailoverValue) Bool() bool {
+	if a.IsString {
+		s := strings.ToLower(a.StringValue)
+		return s == "true" || s == "safe"
+	}
+	return a.BoolValue
+}

--- a/auto_failover_value.go
+++ b/auto_failover_value.go
@@ -19,13 +19,10 @@ import (
 	"strings"
 )
 
-// AutoFailoverValue is a custom type that can handle both bool (true/false) and string values
-// String values are expected to be one of: "true", "false", or "safe" 
-// This is to support all maxscale versions: in addition to pre-25.x all 25.x new releases
+// AutoFailoverValue is a custom type that can handle both bool and string values
+// String values are expected to be one of: "true", "false", or "safe"
 type AutoFailoverValue struct {
-	StringValue string
-	BoolValue   bool
-	IsString    bool
+	BoolValue bool
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface
@@ -34,8 +31,6 @@ func (a *AutoFailoverValue) UnmarshalJSON(data []byte) error {
 	var boolValue bool
 	if err := json.Unmarshal(data, &boolValue); err == nil {
 		a.BoolValue = boolValue
-		a.StringValue = ""
-		a.IsString = false
 		return nil
 	}
 
@@ -44,18 +39,9 @@ func (a *AutoFailoverValue) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &stringValue); err == nil {
 		// Validate that the string is one of the expected enum values
 		lowerValue := strings.ToLower(stringValue)
-		if lowerValue == "true" || lowerValue == "false" || lowerValue == "safe" {
-			a.StringValue = stringValue
-			a.BoolValue = false
-			a.IsString = true
-			return nil
-		} else {
-			// If not a valid enum value, default to "false"
-			a.StringValue = "false"
-			a.BoolValue = false
-			a.IsString = true
-			return nil
-		}
+		// Set BoolValue to true for "true" or "safe", false otherwise
+		a.BoolValue = lowerValue == "true" || lowerValue == "safe"
+		return nil
 	}
 
 	// If neither, return error
@@ -64,31 +50,10 @@ func (a *AutoFailoverValue) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaler interface
 func (a AutoFailoverValue) MarshalJSON() ([]byte, error) {
-	if a.IsString {
-		return json.Marshal(a.StringValue)
-	}
 	return json.Marshal(a.BoolValue)
 }
 
-// String returns the string representation
-// For boolean values: true becomes "true", false becomes "false"
-// For string values: returns the original string value ("true", "false", or "safe")
-func (a AutoFailoverValue) String() string {
-	if a.IsString {
-		return a.StringValue
-	}
-	if a.BoolValue {
-		return "true"
-	}
-	return "false"
-}
-
 // Bool returns the boolean value
-// For string values: "true" returns true, "safe" returns true, all others return false
 func (a AutoFailoverValue) Bool() bool {
-	if a.IsString {
-		s := strings.ToLower(a.StringValue)
-		return s == "true" || s == "safe"
-	}
 	return a.BoolValue
 }

--- a/auto_failover_value.go
+++ b/auto_failover_value.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 )
 
@@ -45,7 +46,7 @@ func (a *AutoFailoverValue) UnmarshalJSON(data []byte) error {
 	}
 
 	// If neither, return error
-	return json.Unmarshal(data, nil)
+	return errors.New("Cannot find AutoFailoverValue in JSON")
 }
 
 // MarshalJSON implements the json.Marshaler interface

--- a/auto_failover_value.go
+++ b/auto_failover_value.go
@@ -20,7 +20,8 @@ import (
 )
 
 // AutoFailoverValue is a custom type that can handle both bool (true/false) and string values
-// String values are expected to be one of: "true", "false", or "safe"
+// String values are expected to be one of: "true", "false", or "safe" 
+// This is to support all maxscale versions: in addition to pre-25.x all 25.x new releases
 type AutoFailoverValue struct {
 	StringValue string
 	BoolValue   bool

--- a/maxctrl_exporter.go
+++ b/maxctrl_exporter.go
@@ -322,13 +322,15 @@ func (m *MaxScale) parseMonitors(ch chan<- prometheus.Metric) error {
 		m.createMetricForPrometheus(m.monitorMetrics, "monitor_primary", primary, ch, monitor.ID, monitor.Attributes.Parameters.CooperativeMonitoringLocks)
 
 		auto_failover := 0
-		if monitor.Attributes.Parameters.AutoFailover {
+		// Use the Bool() method of AutoFailoverValue which handles specific enum values
+		// "true" and "safe" are considered true, all others are false
+		if monitor.Attributes.Parameters.AutoFailover.Bool() {
 			auto_failover = 1
 		}
 		m.createMetricForPrometheus(m.monitorMetrics, "monitor_auto_failover", auto_failover, ch, monitor.ID, monitor.Attributes.Parameters.CooperativeMonitoringLocks)
 
 		auto_rejoin := 0
-		if monitor.Attributes.Parameters.AutoFailover {
+		if monitor.Attributes.Parameters.AutoRejoin {
 			auto_rejoin = 1
 		}
 		m.createMetricForPrometheus(m.monitorMetrics, "monitor_auto_rejoin", auto_rejoin, ch, monitor.ID, monitor.Attributes.Parameters.CooperativeMonitoringLocks)

--- a/maxctrl_exporter.go
+++ b/maxctrl_exporter.go
@@ -289,6 +289,12 @@ func (m *MaxScale) parseMaxscaleStatus(ch chan<- prometheus.Metric) error {
 	m.createMetricForPrometheus(m.maxscaleStatusMetrics, "status_threads",
 		maxscaleStatus.Data.Attributes.Parameters.Threads, ch)
 
+	m.createMetricForPrometheus(m.maxscaleStatusMetrics, "status_writeq_high_water",
+		maxscaleStatus.Data.Attributes.Parameters.WriteqHighWater, ch)
+
+	m.createMetricForPrometheus(m.maxscaleStatusMetrics, "status_writeq_low_water",
+		maxscaleStatus.Data.Attributes.Parameters.WriteqLowWater, ch)
+
 	passiveMode := 0
 	if maxscaleStatus.Data.Attributes.Parameters.Passive {
 		passiveMode = 1

--- a/maxscale_api.go
+++ b/maxscale_api.go
@@ -92,9 +92,9 @@ type Monitors struct {
 			} `json:"monitor_diagnostics"`
 			//nolint
 			Parameters struct {
-				CooperativeMonitoringLocks string `json:"cooperative_monitoring_locks"`
-				AutoFailover               bool   `json:"auto_failover"`
-				AutoRejoin                 bool   `json:"auto_rejoin"`
+				CooperativeMonitoringLocks string           `json:"cooperative_monitoring_locks"`
+				AutoFailover               AutoFailoverValue `json:"auto_failover"`
+				AutoRejoin                 bool             `json:"auto_rejoin"`
 			} `json:"parameters"`
 			//nolint
 		} `json:"attributes"`

--- a/maxscale_api.go
+++ b/maxscale_api.go
@@ -116,6 +116,8 @@ type MaxscaleStatus struct {
 		Attributes struct {
 			Parameters struct {
 				Threads int  `json:"threads"`
+				WriteqHighWater int  `json:"writeq_high_water"`
+				WriteqLowWater int  `json:"writeq_low_water"`
 				Passive bool `json:"passive"`
 				// add other parameters if needed
 			} `json:"parameters"`

--- a/prometheus_metrics.go
+++ b/prometheus_metrics.go
@@ -90,7 +90,7 @@ var (
 
 	MonitorMetrics = metrics{
 		"monitor_primary":       newDesc("monitor", "primary", "Is a primary node", monitorLabelNames, prometheus.GaugeValue),
-		"monitor_auto_failover": newDesc("monitor", "auto_failover", "Is auto-failover enable", monitorLabelNames, prometheus.CounterValue),
+		"monitor_auto_failover": newDesc("monitor", "auto_failover", "Is auto-failover enabled (1 for true/safe, 0 for false)", monitorLabelNames, prometheus.CounterValue),
 		"monitor_auto_rejoin":   newDesc("monitor", "auto_rejoin", "Is auto-rejoin enable", monitorLabelNames, prometheus.GaugeValue),
 	}
 )

--- a/prometheus_metrics.go
+++ b/prometheus_metrics.go
@@ -61,6 +61,8 @@ var (
 	MaxscaleStatusMetrics = metrics{
 		"status_uptime":  newDesc("status", "uptime", "How long has the server been running", maxscaleStatusLabelNames, prometheus.GaugeValue),
 		"status_threads": newDesc("status", "threads", "Number of worker threads", maxscaleStatusLabelNames, prometheus.GaugeValue),
+		"status_writeq_high_water": newDesc("status", "writeq_high_water", "High water mark for network write buffer", maxscaleStatusLabelNames, prometheus.GaugeValue),
+		"status_writeq_low_water": newDesc("status", "writeq_low_water", "Low water mark for network write buffer", maxscaleStatusLabelNames, prometheus.GaugeValue),
 		"status_passive": newDesc("status", "passive", "Has passive mode", maxscaleStatusLabelNames, prometheus.GaugeValue),
 	}
 


### PR DESCRIPTION
We are at Nokia started using new Maxscale major releases 25.01.x & 25.10.x and we found after communicating with MariaDB/Maxscale development team that they changed one of the counters from the maxscale-api -- auto_failover from bool (true/false) to string to accommodate three states "true", "false", "safe". This broke exiting maxctrl_exporter which expects only a bool (true/false). We also still supporting old maxscale versions (23.08.x, 24.02.x) where this is of a bool type.
we defined a type-struct that can accept the old way true/false (bool) and the new releases "true","false","safe" (string).